### PR TITLE
Continuous Integration (CI)

### DIFF
--- a/.github/workflows/exercise.yaml
+++ b/.github/workflows/exercise.yaml
@@ -1,0 +1,28 @@
+name: Exercise
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: '8'
+
+      - name: Package
+        run: mvn package
+
+      - name: Run for 'card'
+        run: java -jar target/ki-takehome-kotlin-1.0-SNAPSHOT.jar card_payments_example.csv card 1.20
+      
+      - name: Run for 'bank'
+        run: java -jar target/ki-takehome-kotlin-1.0-SNAPSHOT.jar bank_payments_example.csv bank 1.20


### PR DESCRIPTION
Now that I've had a first run at the exercise in https://github.com/QuintinWillison/ki-insurance-kotlin-take-home/pull/3, it seemed like an appropriate time to gain myself some reassurance for future pull requests I push up to this GitHub repository.

This pull request adds a GitHub workflow which runs the same commands outlined in the readme for packaging and running the code for `'card'` and `'bank'` cases.