### PR TITLE
Exercise: Take 2 - 🚀 - robust approach

### DIFF
--- a/src/main/kotlin/com/ki/io/BankPaymentsCSVFileReader.kt
+++ b/src/main/kotlin/com/ki/io/BankPaymentsCSVFileReader.kt
@@ -1,0 +1,14 @@
+package com.ki.io
+
+import com.ki.models.Payment
+import java.io.FileReader
+
+private val ADDITIONAL_HEADERS = listOf("bank_account_id")
+
+internal class BankPaymentsCSVFileReader(
+    fileReader: FileReader,
+) : PaymentsCSVFileReader(fileReader, ADDITIONAL_HEADERS) {
+    override fun createPayment(fieldValues: List<String>): Payment {
+        return Payment(fieldValues.toTypedArray())
+    }
+}

--- a/src/main/kotlin/com/ki/io/BankPaymentsCSVFileReader.kt
+++ b/src/main/kotlin/com/ki/io/BankPaymentsCSVFileReader.kt
@@ -9,6 +9,6 @@ internal class BankPaymentsCSVFileReader(
     fileReader: FileReader,
 ) : PaymentsCSVFileReader(fileReader, ADDITIONAL_HEADERS) {
     override fun createPayment(fieldValues: List<String>): Payment {
-        return Payment(fieldValues.toTypedArray())
+        return Payment.bank(fieldValues.toTypedArray())
     }
 }

--- a/src/main/kotlin/com/ki/io/CSVFileReader.kt
+++ b/src/main/kotlin/com/ki/io/CSVFileReader.kt
@@ -1,0 +1,30 @@
+package com.ki.io
+
+import com.opencsv.CSVReaderBuilder
+import java.io.FileReader
+
+internal abstract class CSVFileReader(private val fileReader: FileReader) {
+    abstract fun onHeaderRow(fieldNames: List<String>)
+    abstract fun onBodyRow(fieldValues: List<String>)
+
+    fun readAll() {
+        val reader = CSVReaderBuilder(fileReader).build()
+
+        var hadHeaderRow = false
+        var isFinished = false
+        do {
+            val fieldArray = reader.readNext()
+            if (null == fieldArray) {
+                isFinished = true
+            } else {
+                val fieldValues = fieldArray.toList()
+                if (hadHeaderRow) {
+                    onBodyRow(fieldValues)
+                } else {
+                    hadHeaderRow = true
+                    onHeaderRow(fieldValues)
+                }
+            }
+        } while (!isFinished)
+    }
+}

--- a/src/main/kotlin/com/ki/io/CardPaymentsCSVFileReader.kt
+++ b/src/main/kotlin/com/ki/io/CardPaymentsCSVFileReader.kt
@@ -1,0 +1,14 @@
+package com.ki.io
+
+import com.ki.models.Payment
+import java.io.FileReader
+
+private val ADDITIONAL_HEADERS = listOf("card_id", "card_status")
+
+internal class CardPaymentsCSVFileReader(
+    fileReader: FileReader,
+) : PaymentsCSVFileReader(fileReader, ADDITIONAL_HEADERS) {
+    override fun createPayment(fieldValues: List<String>): Payment {
+        return Payment(fieldValues.toTypedArray())
+    }
+}

--- a/src/main/kotlin/com/ki/io/InvalidDataException.kt
+++ b/src/main/kotlin/com/ki/io/InvalidDataException.kt
@@ -1,0 +1,3 @@
+package com.ki.io
+
+internal class InvalidDataException(message: String) : Exception(message)

--- a/src/main/kotlin/com/ki/io/PaymentsCSVFileReader.kt
+++ b/src/main/kotlin/com/ki/io/PaymentsCSVFileReader.kt
@@ -1,0 +1,29 @@
+package com.ki.io
+
+import com.ki.models.Payment
+import java.io.FileReader
+
+private val COMMON_FIELD_NAMES = listOf("customer_id", "date", "amount")
+
+internal abstract class PaymentsCSVFileReader(
+    fileReader: FileReader,
+    additionalFieldNames: List<String>,
+) : CSVFileReader(fileReader) {
+    private val FIELD_NAMES = COMMON_FIELD_NAMES + additionalFieldNames
+    private val _payments = mutableListOf<Payment>()
+
+    override fun onHeaderRow(fieldNames: List<String>) {
+        if (fieldNames != FIELD_NAMES) {
+            throw InvalidDataException("Unexpected field names in header row. Expected $FIELD_NAMES but found $fieldNames.")
+        }
+    }
+
+    override fun onBodyRow(fieldValues: List<String>) {
+        _payments.add(createPayment(fieldValues))
+    }
+
+    abstract fun createPayment(fieldValues: List<String>): Payment
+
+    val payments: List<Payment>
+        get() = _payments.toList()
+}

--- a/src/test/kotlin/com/ki/Fixture.kt
+++ b/src/test/kotlin/com/ki/Fixture.kt
@@ -1,6 +1,7 @@
 package com.ki
 
 import java.io.File
+import java.io.FileReader
 import java.io.IOException
 
 object Fixture {
@@ -12,5 +13,9 @@ object Fixture {
             e.printStackTrace()
         }
         return "$selfPath/src/test/fixtures/$filename"
+    }
+
+    fun createCSVFileReader(filename: String): FileReader {
+        return FileReader(getPath("$filename.csv"))
     }
 }

--- a/src/test/kotlin/com/ki/io/BankPaymentsCSVFileReaderTest.kt
+++ b/src/test/kotlin/com/ki/io/BankPaymentsCSVFileReaderTest.kt
@@ -1,0 +1,41 @@
+package com.ki.io
+
+import com.ki.Fixture
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class BankPaymentsCSVFileReaderTest {
+    @Test
+    fun empty() {
+        val reader = createAndExerciseReader("bank_payments_empty")
+        assertEquals(0, reader.payments.size)
+    }
+
+    @Test
+    fun mixed() {
+        val reader = createAndExerciseReader("bank_payments_mixed")
+        assertEquals(4, reader.payments.size)
+
+        // not testing all fields, just a sampling
+        val payments = reader.payments
+        assertEquals(345, payments[1].customerId)
+        assertNull(payments[0].card)
+    }
+
+    @Test(expected = InvalidDataException::class)
+    fun cardEmpty() {
+        createAndExerciseReader("card_payments_empty")
+    }
+
+    @Test(expected = InvalidDataException::class)
+    fun cardMixed() {
+        createAndExerciseReader("card_payments_mixed")
+    }
+
+    private fun createAndExerciseReader(csvFileName: String): PaymentsCSVFileReader {
+        val reader = BankPaymentsCSVFileReader(Fixture.createCSVFileReader(csvFileName))
+        reader.readAll()
+        return reader
+    }
+}

--- a/src/test/kotlin/com/ki/io/CSVFileReaderTest.kt
+++ b/src/test/kotlin/com/ki/io/CSVFileReaderTest.kt
@@ -1,0 +1,100 @@
+package com.ki.io
+
+import com.ki.Fixture
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import java.io.FileReader
+import kotlin.test.assertNull
+
+class CSVFileReaderTest {
+    private val EXPECTED_CARD_HEADERS = listOf("customer_id", "date", "amount", "card_id", "card_status")
+    private val EXPECTED_BANK_HEADERS = listOf("customer_id", "date", "amount", "bank_account_id")
+
+    @Test
+    fun cardPaymentsEmpty() {
+        val reader = createAndExerciseReader("card_payments_empty")
+        assertThat(reader.headerRow, `is`(EXPECTED_CARD_HEADERS))
+        assertNull(reader.bodyRows)
+    }
+
+    @Test
+    fun cardPaymentsMixed() {
+        val reader = createAndExerciseReader("card_payments_mixed")
+        assertThat(reader.headerRow, `is`(EXPECTED_CARD_HEADERS))
+        assertThat(
+            reader.bodyRows,
+            `is`(
+                listOf(
+                    listOf("123", "2019-01-12", "900", "30", "processed"),
+                    listOf("123", "2019-02-10", "900", "45", "declined"),
+                    listOf("456", "2019-01-20", "4200", "10", "processed"),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun bankPaymentsEmpty() {
+        val reader = createAndExerciseReader("bank_payments_empty")
+        assertThat(reader.headerRow, `is`(EXPECTED_BANK_HEADERS))
+        assertNull(reader.bodyRows)
+    }
+
+    @Test
+    fun bankPaymentsMixed() {
+        val reader = createAndExerciseReader("bank_payments_mixed")
+        assertThat(reader.headerRow, `is`(EXPECTED_BANK_HEADERS))
+        assertThat(
+            reader.bodyRows,
+            `is`(
+                listOf(
+                    listOf("789", "2018-10-25", "900", "20"),
+                    listOf("345", "2018-11-03", "900", "60"),
+                    listOf("1", "2022-01-28", "3", "5"),
+                    listOf("2", "2022-01-29", "4", "6"),
+                ),
+            ),
+        )
+    }
+
+    private fun createAndExerciseReader(csvFileName: String): AccumulatingCSVFileReader {
+        val reader = AccumulatingCSVFileReader(FileReader(Fixture.getPath("$csvFileName.csv")))
+        reader.readAll()
+        return reader
+    }
+
+    private class AccumulatingCSVFileReader(
+        fileReader: FileReader,
+    ) : CSVFileReader(fileReader) {
+        private var _headerRow: List<String>? = null
+        private var _bodyRows: MutableList<List<String>>? = null
+
+        override fun onHeaderRow(fieldNames: List<String>) {
+            if (null != _headerRow) {
+                throw IllegalStateException("Received more than one call to onHeaderRow.")
+            }
+            _headerRow = fieldNames
+        }
+
+        override fun onBodyRow(fieldValues: List<String>) {
+            bodyRowsAccumulator.add(fieldValues)
+        }
+
+        private val bodyRowsAccumulator: MutableList<List<String>>
+            get() {
+                // TODO Replace this with something Kotlin-idiomatic.
+                // This is very much "Java-flavoured".
+                if (null == _bodyRows) {
+                    _bodyRows = mutableListOf()
+                }
+                return _bodyRows!!
+            }
+
+        val headerRow: List<String>?
+            get() = _headerRow
+
+        val bodyRows: List<List<String>>?
+            get() = _bodyRows
+    }
+}

--- a/src/test/kotlin/com/ki/io/CSVFileReaderTest.kt
+++ b/src/test/kotlin/com/ki/io/CSVFileReaderTest.kt
@@ -59,7 +59,7 @@ class CSVFileReaderTest {
     }
 
     private fun createAndExerciseReader(csvFileName: String): AccumulatingCSVFileReader {
-        val reader = AccumulatingCSVFileReader(FileReader(Fixture.getPath("$csvFileName.csv")))
+        val reader = AccumulatingCSVFileReader(Fixture.createCSVFileReader(csvFileName))
         reader.readAll()
         return reader
     }

--- a/src/test/kotlin/com/ki/io/CardPaymentsCSVFileReaderTest.kt
+++ b/src/test/kotlin/com/ki/io/CardPaymentsCSVFileReaderTest.kt
@@ -1,0 +1,42 @@
+package com.ki.io
+
+import com.ki.Fixture
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class CardPaymentsCSVFileReaderTest {
+    @Test
+    fun empty() {
+        val reader = createAndExerciseReader("card_payments_empty")
+        assertEquals(0, reader.payments.size)
+    }
+
+    @Test
+    fun mixed() {
+        val reader = createAndExerciseReader("card_payments_mixed")
+        assertEquals(3, reader.payments.size)
+
+        // not testing all fields, just a sampling
+        val payments = reader.payments
+        assertEquals(123, payments[0].customerId)
+        assertEquals("processed", payments[0].card!!.status)
+        assertEquals(45, payments[1].card!!.cardId)
+        assertEquals("declined", payments[1].card!!.status)
+    }
+
+    @Test(expected = InvalidDataException::class)
+    fun bankEmpty() {
+        createAndExerciseReader("bank_payments_empty")
+    }
+
+    @Test(expected = InvalidDataException::class)
+    fun bankMixed() {
+        createAndExerciseReader("bank_payments_mixed")
+    }
+
+    private fun createAndExerciseReader(csvFileName: String): PaymentsCSVFileReader {
+        val reader = CardPaymentsCSVFileReader(Fixture.createCSVFileReader(csvFileName))
+        reader.readAll()
+        return reader
+    }
+}

--- a/src/test/kotlin/com/ki/io/PaymentsCSVFileReaderTest.kt
+++ b/src/test/kotlin/com/ki/io/PaymentsCSVFileReaderTest.kt
@@ -1,0 +1,80 @@
+package com.ki.io
+
+import com.ki.Fixture
+import com.ki.models.Payment
+import org.junit.Test
+import java.io.FileReader
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class PaymentsCSVFileReaderTest {
+    private val ADDITIONAL_CARD_HEADERS = listOf("card_id", "card_status")
+    private val ADDITIONAL_BANK_HEADERS = listOf("bank_account_id")
+
+    @Test(expected = InvalidDataException::class)
+    fun invalidHeaderWrongSourceWhenExpectingBank() {
+        val reader = createAndExerciseReader("card_payments_mixed", ADDITIONAL_BANK_HEADERS)
+    }
+
+    @Test(expected = InvalidDataException::class)
+    fun invalidHeaderWrongSourceWhenExpectingCard() {
+        val reader = createAndExerciseReader("bank_payments_mixed", ADDITIONAL_CARD_HEADERS)
+    }
+
+    @Test
+    fun cardPaymentsEmpty() {
+        val reader = createAndExerciseReader("card_payments_empty", ADDITIONAL_CARD_HEADERS)
+        assertEquals(0, reader.payments.size)
+    }
+
+    @Test
+    fun cardPaymentsMixed() {
+        val reader = createAndExerciseReader("card_payments_mixed", ADDITIONAL_CARD_HEADERS)
+        assertEquals(3, reader.payments.size)
+
+        // not testing all fields, just a sampling
+        val payments = reader.payments
+        assertEquals(123, payments[0].customerId)
+        assertEquals("processed", payments[0].card!!.status)
+        assertEquals(45, payments[1].card!!.cardId)
+        assertEquals("declined", payments[1].card!!.status)
+    }
+
+    @Test
+    fun bankPaymentsEmpty() {
+        val reader = createAndExerciseReader("bank_payments_empty", ADDITIONAL_BANK_HEADERS)
+        assertEquals(0, reader.payments.size)
+    }
+
+    @Test
+    fun bankPaymentsMixed() {
+        val reader = createAndExerciseReader("bank_payments_mixed", ADDITIONAL_BANK_HEADERS)
+        assertEquals(4, reader.payments.size)
+
+        // not testing all fields, just a sampling
+        val payments = reader.payments
+        assertEquals(345, payments[1].customerId)
+        assertNull(payments[0].card)
+    }
+
+    private fun createAndExerciseReader(
+        csvFileName: String,
+        additionalFieldNames: List<String>,
+    ): PaymentsCSVFileReader {
+        val reader = DumbPaymentsCSVFileReader(
+            Fixture.createCSVFileReader(csvFileName),
+            additionalFieldNames,
+        )
+        reader.readAll()
+        return reader
+    }
+
+    private class DumbPaymentsCSVFileReader(
+        fileReader: FileReader,
+        additionalFieldNames: List<String>,
+    ) : PaymentsCSVFileReader(fileReader, additionalFieldNames) {
+        override fun createPayment(fieldValues: List<String>): Payment {
+            return Payment(fieldValues.toTypedArray())
+        }
+    }
+}

--- a/src/test/kotlin/com/ki/io/PaymentsCSVFileReaderTest.kt
+++ b/src/test/kotlin/com/ki/io/PaymentsCSVFileReaderTest.kt
@@ -5,7 +5,6 @@ import com.ki.models.Payment
 import org.junit.Test
 import java.io.FileReader
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
 class PaymentsCSVFileReaderTest {
     private val ADDITIONAL_CARD_HEADERS = listOf("card_id", "card_status")
@@ -46,15 +45,14 @@ class PaymentsCSVFileReaderTest {
         assertEquals(0, reader.payments.size)
     }
 
-    @Test
+    /**
+     * Our [DumbPaymentsCSVFileReader] uses the original, public constructor which
+     * only supports card payment records, not bank payment records.
+     * Hence, this test expects to fail.
+     */
+    @Test(expected = InvalidDataException::class)
     fun bankPaymentsMixed() {
-        val reader = createAndExerciseReader("bank_payments_mixed", ADDITIONAL_BANK_HEADERS)
-        assertEquals(4, reader.payments.size)
-
-        // not testing all fields, just a sampling
-        val payments = reader.payments
-        assertEquals(345, payments[1].customerId)
-        assertNull(payments[0].card)
+        createAndExerciseReader("bank_payments_mixed", ADDITIONAL_BANK_HEADERS)
     }
 
     private fun createAndExerciseReader(

--- a/src/test/kotlin/com/ki/models/PaymentTest.kt
+++ b/src/test/kotlin/com/ki/models/PaymentTest.kt
@@ -69,7 +69,7 @@ class PaymentTest {
             AMOUNT,
             ACCOUNT_ID.toString(),
         )
-        val payment = Payment(data)
+        val payment = Payment.bank(data)
         Assert.assertEquals(CUSTOMER_ID, payment.customerId)
         Assert.assertEquals(1960, payment.amount)
         Assert.assertEquals(40, payment.fee)


### PR DESCRIPTION
For this second pass at solving this I've focussed on making the CSV parsing more robust.

There are many other facets of this codebase that I _could_ have tackled - both in terms of internal implementation details that could be improved, as well as proposals for public API improvements - however I felt that this particular area needed the most improvement.

It's also clear there is more I could have even done in this area (for example, support CSV files with fields/columns in a different order) - however, based on the input data files I was provided, I decided to focus on supporting their exact structure, allowing myself to make the assumptions that future files would follow the same form.

This pull request is made up of the following parts:

1. **Groundwork**:
    1. Create a _CSV file reader_, with separation between header row validation and body row reads in https://github.com/QuintinWillison/ki-insurance-kotlin-take-home/pull/5/commits/c6954609c1d93d765c9deaab7d4db679116f231e
    2. Create a _payments reader_, extending the CSV file reader, with support for the field/column names that are common between card and bank payment records in https://github.com/QuintinWillison/ki-insurance-kotlin-take-home/pull/5/commits/eebd145d9770b05ee964fbfc59ce0d8160133b53
    3. Create _dedicated card and bank payment readers_, extending the payments reader, each with knowledge of the additional field/column names for their record type in https://github.com/QuintinWillison/ki-insurance-kotlin-take-home/pull/5/commits/1c0d4e792d7fd584abfc8abf61af97dfeccf0231 and https://github.com/QuintinWillison/ki-insurance-kotlin-take-home/pull/5/commits/f323707599e337b41da2aae8dceca2833f7586bd
2. Finally, bring it all together in https://github.com/QuintinWillison/ki-insurance-kotlin-take-home/pull/5/commits/6476265b265f68e13ba1f574da853e55d8c2358a, to replace the first-pass/brittle solution I presented in https://github.com/QuintinWillison/ki-insurance-kotlin-take-home/pull/3